### PR TITLE
Split is_tw_boat() into two parts

### DIFF
--- a/ConfAnalyser/application.cpp
+++ b/ConfAnalyser/application.cpp
@@ -169,15 +169,18 @@ bool Application::process_file(Molecule* mol, string file_name)
         
         if (!read_PDB(file_name, molecule))
         {
+                cerr << "Problem while reading PDB " << file_name << "...\n";
                 goto ERROR;
         }
 
         if (!mol->initialize(molecule))
         {
+                cerr << "Problem while initializing molecule " << file_name << "...\n";
                 goto ERROR;
         }
 
         if (!mol->analyse()) {
+                cerr << "Problem while analysing " << file_name << "...\n";
                 goto ERROR;
         }
 

--- a/ConfAnalyser/cyclohexane.cpp
+++ b/ConfAnalyser/cyclohexane.cpp
@@ -259,9 +259,9 @@ bool Cyclohexane::analyse()
         } else if (is_boat()) {
                 conformation = conformations["BOAT"];
         } else if (is_tw_boat_right()) {
-		conformation = conformations["TW_BOAT_RIGHT"];
+		conformation = conformations["TW_BOAT_R"];
         } else if (is_tw_boat_left()) {
-		conformation = conformations["TW_BOAT_LEFT"];
+		conformation = conformations["TW_BOAT_L"];
         } else if (is_chair()) {
                 conformation = conformations["CHAIR"];
         } else {

--- a/ConfAnalyser/cyclohexane.cpp
+++ b/ConfAnalyser/cyclohexane.cpp
@@ -19,8 +19,6 @@ Cyclohexane::Cyclohexane(string _structure) : Six_atom_ring(_structure)
         conformations.insert({"CHAIR", 3});
         conformations.insert({"TW_BOAT_R", 4});
         conformations.insert({"TW_BOAT_L", 5});
-        conformations.insert({"TW_BOAT_R", 4});
-        conformations.insert({"TW_BOAT_L", 5});
         conformations.insert({"HALF_CHAIR", 6});
         conformations.insert({"BOAT", 7});
 }

--- a/ConfAnalyser/cyclohexane.cpp
+++ b/ConfAnalyser/cyclohexane.cpp
@@ -19,6 +19,8 @@ Cyclohexane::Cyclohexane(string _structure) : Six_atom_ring(_structure)
         conformations.insert({"CHAIR", 3});
         conformations.insert({"TW_BOAT_R", 4});
         conformations.insert({"TW_BOAT_L", 5});
+        conformations.insert({"TW_BOAT_R", 4});
+        conformations.insert({"TW_BOAT_L", 5});
         conformations.insert({"HALF_CHAIR", 6});
         conformations.insert({"BOAT", 7});
 }
@@ -97,10 +99,22 @@ bool Cyclohexane::initialize(const vector<Atom*> &atoms)
         return filled;
 }
 
-
+/**
+ * @brief Checks if the cyclohexane is in a flat conformation.
+ * 
+ * The analysis involves checking the relative positions of specific atoms in the cyclohexane ring.
+ * - Flat conformation has all atoms in one plane
+ * - The approach used in this function uses and analyzes two planes, right and left one, which should be almost identical.
+ * - Left plane includes atoms 0, 1, 4.
+ * - Right plane includes atoms 0, 1, 3.
+ * - Atoms 2 and 5 should both lie on the left plane and on the right plane simultaneously
+ * - The constant value <tolerance_flat_in> allows some deviation from that rule.
+ * 
+ * @return true 
+ * @return false 
+ */
 bool Cyclohexane::is_flat() const
 {
-        /* flat conformation has all atoms in one plane */
         if (!has_plane) {
                 return false;
         }
@@ -108,15 +122,26 @@ bool Cyclohexane::is_flat() const
         Plane_3D left_plane(*(C[begin]), *(C[(begin+1)%6]), *(C[(begin+4)%6]));
         Plane_3D right_plane(*(C[begin]), *(C[(begin+1)%6]), *(C[(begin+3)%6]));
         return left_plane.is_on_plane(*(C[(begin+2)%6]), tolerance_flat_in) &&
-               left_plane.is_on_plane(*(C[(begin+5)%6]), tolerance_flat_in) &&  // are atoms 2 and 5 on the left plane?
+               left_plane.is_on_plane(*(C[(begin+5)%6]), tolerance_flat_in) &&  
                right_plane.is_on_plane(*(C[(begin+2)%6]), tolerance_flat_in) &&
                right_plane.is_on_plane(*(C[(begin+5)%6]), tolerance_flat_in);   // are atoms 2 and 5 on the right plane?
 }
 
-
+/**
+ * @brief Checks if the cyclohexane is in a half-chair conformation.
+ * 
+ * The analysis involves checking the relative positions of specific atoms in the cyclohexane ring.
+ * - Half-chair has all but one atom in one plane (atoms 0, 1, 3)
+ * - Atom 2 or 5 (but not both) should not lie on the plane.
+ * - Atom 4 should lie on the plane.
+ * - Atom 2 or 5 should be far enough from the plane.
+ * - The constants <tolerance_flat_in> and <tolerance_out> allow some deviations.
+ * 
+ * @return true 
+ * @return false 
+ */
 bool Cyclohexane::is_half_chair() const
 {
-        /* half chair has all but one atom in one plane */
         if (!has_plane) {
                 return false;
         }
@@ -125,21 +150,24 @@ bool Cyclohexane::is_half_chair() const
         double right_dist = plane.distance_from(*(C[(begin+2)%6]));
         double left_dist = plane.distance_from(*(C[(begin+5)%6]));
         return (plane.is_on_plane(*(C[(begin+2)%6]), tolerance_flat_in) !=
-                plane.is_on_plane(*(C[(begin+5)%6]), tolerance_flat_in)) &&     // is atom 2 or 5 (not both) not on the plane?
-               plane.is_on_plane(*(C[(begin+4)%6]), tolerance_flat_in) &&       // is atom 4 on a plane?
+                plane.is_on_plane(*(C[(begin+5)%6]), tolerance_flat_in)) &&     
+               plane.is_on_plane(*(C[(begin+4)%6]), tolerance_flat_in) &&       
                ((abs(right_dist) > tolerance_out) !=
-                (abs(left_dist) > tolerance_out));                              // is atom 2 or 5 far enough from the plane to make the half chair?
+                (abs(left_dist) > tolerance_out));                              
 }
 
 /**
- * @brief Checks if the ring is of chair shape
+ * @brief Checks if the cyclohexane is in a chair conformation.
+ * 
+ * The analysis involves checking the relative positions of specific atoms in the cyclohexane ring.
+ * - Two atoms (2 and 5) of chair are on the opposite sides of plane (atoms 0, 1, 3)
+ * - The atoms 2 and 5 should be far enough from the main plane. The constant <tolerance_out> allows some deviation.
  * 
  * @return true 
  * @return false 
  */
 bool Cyclohexane::is_chair() const
 {
-        /* two atoms of chair are on the opposite sides of plane */
         if (!has_plane) {
                 return false;
         }
@@ -147,19 +175,22 @@ bool Cyclohexane::is_chair() const
         double right_dist = plane.distance_from(*(C[(begin+2)%6]));
         double left_dist = plane.distance_from(*(C[(begin+5)%6]));
         return (abs(right_dist) > tolerance_out &&
-                abs(left_dist) > tolerance_out) &&      // is the distance of atoms out of the plane far enough?
-               (right_dist * left_dist < 0);            // are the left and right planes distances in negative values to make the chair shape?
+                abs(left_dist) > tolerance_out) &&
+               (right_dist * left_dist < 0);            
 }
 
 /**
- * @brief Checks if the ring is of boat shape
+ * @brief Checks if the cyclohexane is in a boat conformation
+ * 
+ * - Two atoms (2 and 5) of boat are on the same side of a plane (atoms 0, 1, 3)
+ * - The distance of atoms 2 and 5 should be far enough from the main plane.
+ * - The constant <tolerance_out> allows some deviation.
  * 
  * @return true 
  * @return false 
  */
 bool Cyclohexane::is_boat() const
 {
-        /* two atoms of boat are on the same side of plane */
         if (!has_plane) {
                 return false;
         }
@@ -167,19 +198,27 @@ bool Cyclohexane::is_boat() const
         double right_dist = plane.distance_from(*(C[(begin+2)%6]));
         double left_dist = plane.distance_from(*(C[(begin+5)%6]));
         return (abs(right_dist) > tolerance_out &&
-                abs(left_dist) > tolerance_out) &&      // is the distance of atoms out of the plane far enough?
-               (right_dist * left_dist > 0);            // are the left and right planes distances in positive values to make the boat shape?
+                abs(left_dist) > tolerance_out) &&      
+               (right_dist * left_dist > 0);           
 }
 
 /**
- * @brief Checks if the ring is of boat shape with right twist.
+ * @brief Checks if the cyclohexane is in a twisted boat conformation (boat with a right twist)
+ * 
+ * - Twisted boat has no plane within the ring
+ * - The approach used in this function uses and analyzes two planes, right and left one
+ * - Left plane includes atoms 0, 1, 4.
+ * - Right plane includes atoms 0, 1, 3.
+ * - The dihedral angle (1-3-4-0) should be in the allowed range (constant <angle_tolerance> allow some deviation)
+ * - The atoms 2 and 5 (out of the plane) should be far enough from that plane. Constant <tolerance_tw_out> allows some deviation
+ * - The atoms 2 and 5 should be on the same side (boat-like)
+ * - The right plane should be further than the left one.
  * 
  * @return true 
  * @return false 
  */
 bool Cyclohexane::is_tw_boat_right() const
 {
-        /* twisted boat has no plane within the circle */
         if (has_plane) {
                 return false;
         }
@@ -197,20 +236,28 @@ bool Cyclohexane::is_tw_boat_right() const
         return ((abs(tw_angle) > angle_tw_boat - angle_tolerance) &&
                 (abs(tw_angle) < angle_tw_boat + angle_tolerance)) &&   // is the twist angle in allowed range?
                ((abs(right_dist) > tolerance_tw_out) &&
-                (abs(left_dist) > tolerance_tw_out)) &&                 // is the distance of atoms out of the plane far enough?
-                (right_dist * left_dist > 0) &&                         // are the left and right planes distances in positive values to make the boat shape?
-                (right_dist > left_dist);                               // is the right plane distance higher to make the right twist boat?
+                (abs(left_dist) > tolerance_tw_out)) &&                
+                (right_dist * left_dist > 0) &&                  
+                (right_dist > left_dist);                              
 }
 
 /**
- * @brief Checks if the ring is of boat shape with left twist.
+ * @brief Checks if the cyclohexane is in a twisted boat conformation (boat with a left twist)
+ * 
+ * - Twisted boat has no plane within the ring
+ * - The approach used in this function uses and analyzes two planes, right and left one
+ * - Left plane includes atoms 0, 1, 4.
+ * - Right plane includes atoms 0, 1, 3.
+ * - The dihedral angle (1-3-4-0) should be in the allowed range (constant <angle_tolerance> allow some deviation)
+ * - The atoms 2 and 5 (out of the plane) should be far enough from that plane. Constant <tolerance_tw_out> allows some deviation
+ * - The atoms 2 and 5 should be on the same side (boat-like)
+ * - The left plane should be further than the right one. (the only difference between this function and <is_tw_boat_right()>)
  * 
  * @return true 
  * @return false 
  */
 bool Cyclohexane::is_tw_boat_left() const
 {
-        /* twisted boat has no plane within the circle */
         if (has_plane) {
                 return false;
         }
@@ -231,11 +278,11 @@ bool Cyclohexane::is_tw_boat_left() const
 					 *(C[(begin+4)%6]), *(C[begin]));
 
         return ((abs(tw_angle) > angle_tw_boat - angle_tolerance) &&
-                (abs(tw_angle) < angle_tw_boat + angle_tolerance)) &&   // is the twist angle in allowed range?
+                (abs(tw_angle) < angle_tw_boat + angle_tolerance)) &&   
                ((abs(right_dist) > tolerance_tw_out) &&
-                (abs(left_dist) > tolerance_tw_out)) &&                 // is the distance of atoms out of the plane far enough?
-                (right_dist * left_dist > 0) &&                         // are the left and right planes distances in positive values to make the boat shape?
-                (right_dist < left_dist);                               // is the left plane distance higher to make the left twist boat?
+                (abs(left_dist) > tolerance_tw_out)) &&                 
+                (right_dist * left_dist > 0) &&                         
+                (right_dist < left_dist);                              
 }
 
 
@@ -260,7 +307,9 @@ bool Cyclohexane::analyse()
                 conformation = conformations["BOAT"];
         } else if (is_tw_boat_right()) {
 		conformation = conformations["TW_BOAT_R"];
+		conformation = conformations["TW_BOAT_R"];
         } else if (is_tw_boat_left()) {
+		conformation = conformations["TW_BOAT_L"];
 		conformation = conformations["TW_BOAT_L"];
         } else if (is_chair()) {
                 conformation = conformations["CHAIR"];

--- a/ConfAnalyser/cyclohexane.cpp
+++ b/ConfAnalyser/cyclohexane.cpp
@@ -17,9 +17,10 @@ using namespace std;
 Cyclohexane::Cyclohexane(string _structure) : Six_atom_ring(_structure)
 {
         conformations.insert({"CHAIR", 3});
-        conformations.insert({"TWISTED BOAT", 4});
-        conformations.insert({"HALF CHAIR", 5});
-        conformations.insert({"BOAT", 6});
+        conformations.insert({"TW_BOAT_RIGHT", 4});
+        conformations.insert({"TW_BOAT_LEFT", 5});
+        conformations.insert({"HALF_CHAIR", 6});
+        conformations.insert({"BOAT", 7});
 }
 
 
@@ -161,7 +162,7 @@ bool Cyclohexane::is_boat() const
 }
 
 
-bool Cyclohexane::is_tw_boat() const
+bool Cyclohexane::is_tw_boat_right() const
 {
         /* twisted boat has no plane within the circle */
         if (has_plane) {
@@ -177,11 +178,41 @@ bool Cyclohexane::is_tw_boat() const
         double left_dist = left_plane.distance_from(*(C[(begin+5)%6]));
         double tw_angle = dihedral_angle(*(C[(begin+1)%6]), *(C[(begin+3)%6]),
 					 *(C[(begin+4)%6]), *(C[begin]));
+
         return ((abs(tw_angle) > angle_tw_boat - angle_tolerance) &&
                 (abs(tw_angle) < angle_tw_boat + angle_tolerance)) &&
                ((abs(right_dist) > tolerance_tw_out) &&
                 (abs(left_dist) > tolerance_tw_out)) &&
-                (right_dist * left_dist > 0);
+                (right_dist * left_dist > 0) &&
+                (right_dist > left_dist);
+}
+
+
+bool Cyclohexane::is_tw_boat_left() const
+{
+        /* twisted boat has no plane within the circle */
+        if (has_plane) {
+                return false;
+        }
+        Plane_3D right_plane(*(C[begin]),
+                             *(C[(begin+1)%6]),
+                             *(C[(begin+3)%6]));
+        Plane_3D left_plane(*(C[begin]),
+                            *(C[(begin+1)%6]),
+                            *(C[(begin+4)%6]));
+        double right_dist = right_plane.distance_from(*(C[(begin+2)%6]));
+        double left_dist = left_plane.distance_from(*(C[(begin+5)%6]));
+        double tw_angle = dihedral_angle(*(C[(begin+1)%6]), *(C[(begin+3)%6]),
+					 *(C[(begin+4)%6]), *(C[begin]));
+
+        // cout << "IS LEFT: " << (right_dist > left_dist) << "\n";
+
+        return ((abs(tw_angle) > angle_tw_boat - angle_tolerance) &&
+                (abs(tw_angle) < angle_tw_boat + angle_tolerance)) &&
+               ((abs(right_dist) > tolerance_tw_out) &&
+                (abs(left_dist) > tolerance_tw_out)) &&
+                (right_dist * left_dist > 0) &&
+                (right_dist < left_dist);
 }
 
 
@@ -201,11 +232,13 @@ bool Cyclohexane::analyse()
         if (is_flat()) {
                 conformation = conformations["FLAT"];
         } else if (is_half_chair()) {
-                conformation = conformations["HALF CHAIR"];
+                conformation = conformations["HALF_CHAIR"];
         } else if (is_boat()) {
                 conformation = conformations["BOAT"];
-        } else if (is_tw_boat()) {
-		conformation = conformations["TWISTED BOAT"];
+        } else if (is_tw_boat_right()) {
+		conformation = conformations["TW_BOAT_RIGHT"];
+        } else if (is_tw_boat_left()) {
+		conformation = conformations["TW_BOAT_LEFT"];
         } else if (is_chair()) {
                 conformation = conformations["CHAIR"];
         } else {

--- a/ConfAnalyser/cyclohexane.h
+++ b/ConfAnalyser/cyclohexane.h
@@ -19,7 +19,8 @@ class Cyclohexane: public Six_atom_ring
                 bool is_half_chair() const;
                 bool is_chair() const;
                 bool is_boat() const; 
-                bool is_tw_boat() const;
+                bool is_tw_boat_right() const;
+                bool is_tw_boat_left() const;
 		/* function verifying atom names for current ligand type */
 		bool is_valid_atom_name(const int atom_number,
 		                        const std::string &name) const;


### PR DESCRIPTION
This PR resolves:
1. problem with cyclohexane by splitting is_tw_boat() into two functions:
   a) is_tw_boat_right()
   b) is_tw_boat_left()
2. missing documentation for cyclohexanes
